### PR TITLE
Fix AI chat close behavior and add table rendering

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -77,7 +77,10 @@ const App = () => {
         const ok = await useAuthStore.getState().refreshTokens();
         if (!ok) {
           logout();
-          toast({ title: "Session expired", description: "Please sign in again." });
+          toast({
+            title: "Session expired",
+            description: "Please sign in again.",
+          });
         }
       })();
       return;
@@ -89,7 +92,10 @@ const App = () => {
       const ok = await useAuthStore.getState().refreshTokens();
       if (!ok) {
         logout();
-        toast({ title: "Session expired", description: "Please sign in again." });
+        toast({
+          title: "Session expired",
+          description: "Please sign in again.",
+        });
       }
       // If refresh succeeds, the effect will rerun due to accessToken change and reschedule
     }, delay);
@@ -147,7 +153,9 @@ const App = () => {
                     <Route
                       path="/filials"
                       element={
-                        <RoleProtectedRoute requiredRoles={["super_admin", "admin"]}>
+                        <RoleProtectedRoute
+                          requiredRoles={["super_admin", "admin"]}
+                        >
                           <Filials />
                         </RoleProtectedRoute>
                       }

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -235,6 +235,7 @@ export default function AIChat({
     [],
   );
   const messages = useChatStore((s) => s.messages);
+  const hydrated = useChatStore((s) => (s as any).hydrated);
   const setStoreMessages = useChatStore((s) => s.setMessages);
   const replaceMessages = useChatStore((s) => s.replaceMessages);
   const [input, setInput] = useState("");
@@ -255,21 +256,14 @@ export default function AIChat({
     scrollToBottom(true);
   }, [messages, isTyping, scrollToBottom, isFullScreen]);
 
-  // Initialize store with welcome message if empty
+  // Initialize store with welcome message only after hydration if empty
   useEffect(() => {
+    if (!hydrated) return;
     if (!messages || messages.length === 0) {
       replaceMessages(initialMessages);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Reset backend conversation only when starting fresh (no prior messages)
-  useEffect(() => {
-    if (!messages || messages.length <= 1) {
-      tryResetBackend(accessToken);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [hydrated]);
 
   useEffect(() => {
     if (isOpen) setTimeout(() => inputRef.current?.focus(), 50);
@@ -550,7 +544,8 @@ export default function AIChat({
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => {
+                    onClick={async () => {
+                      await clearChat();
                       if (page) {
                         if (window.history.length > 1) navigate(-1);
                         else navigate("/dashboard");

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -544,8 +544,9 @@ export default function AIChat({
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={async () => {
-                      await clearChat();
+                    onClick={() => {
+                      // Fire-and-forget reset; do not block closing
+                      clearChat();
                       if (page) {
                         if (window.history.length > 1) navigate(-1);
                         else navigate("/dashboard");

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -545,13 +545,14 @@ export default function AIChat({
                     variant="ghost"
                     size="sm"
                     onClick={() => {
+                      // Close UI immediately in all modes
+                      setIsFullScreen(false);
+                      setIsOpen(false);
                       // Fire-and-forget reset; do not block closing
                       clearChat();
                       if (page) {
                         if (window.history.length > 1) navigate(-1);
                         else navigate("/dashboard");
-                      } else {
-                        setIsOpen(false);
                       }
                     }}
                     className="h-8 w-8 rounded-full"

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -437,7 +437,7 @@ export default function AIChat({
     }
   };
 
-  const showFloatingButton = variant === "floating" && !isOpen && showTrigger;
+  const showFloatingButton = (variant === "floating" || page) && !isOpen && showTrigger;
   const containerFixed = isFullScreen || (variant === "floating" && isOpen);
 
   // Exit fullscreen on Escape

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -356,9 +356,10 @@ export default function AIChat({
     return () => window.removeEventListener("keydown", onKey);
   }, [isFullScreen]);
 
-  // Lock page scroll when chat is open/fullscreen to avoid background moving
+  // Lock page scroll only for fullscreen or dedicated chat page, not for floating dock
   useEffect(() => {
-    if (isOpen || isFullScreen) {
+    const shouldLock = isFullScreen || (page && isOpen);
+    if (shouldLock) {
       const body = document.body;
       const html = document.documentElement;
       const prevBody = body.style.overflow;
@@ -370,7 +371,7 @@ export default function AIChat({
         html.style.overflow = prevHtml;
       };
     }
-  }, [isOpen, isFullScreen]);
+  }, [isOpen, isFullScreen, page]);
 
   return (
     <>

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -9,7 +9,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import {
   Bot,
   Send,
@@ -41,7 +48,9 @@ function formatMessage(t: string): string {
 // Try to extract a JSON object/array from text (plain or fenced code block)
 function extractJsonFromText(text: string): any | null {
   if (!text) return null;
-  const codeBlockMatch = text.match(/```json\s*([\s\S]*?)\s*```/i) || text.match(/```\s*([\s\S]*?)\s*```/i);
+  const codeBlockMatch =
+    text.match(/```json\s*([\s\S]*?)\s*```/i) ||
+    text.match(/```\s*([\s\S]*?)\s*```/i);
   const candidates: string[] = [];
   if (codeBlockMatch?.[1]) candidates.push(codeBlockMatch[1]);
   candidates.push(text);
@@ -57,18 +66,29 @@ function extractJsonFromText(text: string): any | null {
 }
 
 // Parse markdown table into columns and rows
-function parseMarkdownTable(text: string): { columns: string[]; rows: any[] } | null {
-  const lines = text.split(/\n+/).map((l) => l.trim()).filter(Boolean);
+function parseMarkdownTable(
+  text: string,
+): { columns: string[]; rows: any[] } | null {
+  const lines = text
+    .split(/\n+/)
+    .map((l) => l.trim())
+    .filter(Boolean);
   const tableStart = lines.findIndex((l) => /\|/.test(l));
   if (tableStart < 0 || tableStart + 2 >= lines.length) return null;
   const header = lines[tableStart];
   const divider = lines[tableStart + 1];
   if (!/\|/.test(divider) || !/-{3,}/.test(divider)) return null;
-  const cols = header.split("|").map((c) => c.trim()).filter(Boolean);
+  const cols = header
+    .split("|")
+    .map((c) => c.trim())
+    .filter(Boolean);
   const rows: any[] = [];
   for (let i = tableStart + 2; i < lines.length; i++) {
     if (!/\|/.test(lines[i])) break;
-    const cells = lines[i].split("|").map((c) => c.trim()).filter(Boolean);
+    const cells = lines[i]
+      .split("|")
+      .map((c) => c.trim())
+      .filter(Boolean);
     const row: any = {};
     cols.forEach((col, idx) => {
       row[col] = cells[idx] ?? "";
@@ -79,7 +99,9 @@ function parseMarkdownTable(text: string): { columns: string[]; rows: any[] } | 
   return null;
 }
 
-function getStructuredTable(text: string): { columns: string[]; rows: any[] } | null {
+function getStructuredTable(
+  text: string,
+): { columns: string[]; rows: any[] } | null {
   // 1) JSON with {type:'table', columns, rows} or {columns, rows} or array of objects
   const data = extractJsonFromText(text);
   if (data) {
@@ -88,12 +110,15 @@ function getStructuredTable(text: string): { columns: string[]; rows: any[] } | 
         data.reduce<Set<string>>((s, r) => {
           Object.keys(r || {}).forEach((k) => s.add(k));
           return s;
-        }, new Set<string>())
+        }, new Set<string>()),
       );
       return { columns: cols, rows: data };
     }
     if (data && typeof data === "object") {
-      if (Array.isArray((data as any).rows) && ((data as any).columns || (data as any).headers)) {
+      if (
+        Array.isArray((data as any).rows) &&
+        ((data as any).columns || (data as any).headers)
+      ) {
         const columns = (data as any).columns || (data as any).headers;
         return { columns, rows: (data as any).rows };
       }
@@ -103,7 +128,7 @@ function getStructuredTable(text: string): { columns: string[]; rows: any[] } | 
           rows.reduce<Set<string>>((s: Set<string>, r: any) => {
             Object.keys(r || {}).forEach((k) => s.add(k));
             return s;
-          }, new Set<string>())
+          }, new Set<string>()),
         );
         return { columns: cols, rows };
       }
@@ -125,7 +150,9 @@ function renderMessageContent(text: string) {
           <TableHeader>
             <TableRow>
               {columns.map((col) => (
-                <TableHead key={col} className="whitespace-nowrap">{col}</TableHead>
+                <TableHead key={col} className="whitespace-nowrap">
+                  {col}
+                </TableHead>
               ))}
             </TableRow>
           </TableHeader>
@@ -437,7 +464,8 @@ export default function AIChat({
     }
   };
 
-  const showFloatingButton = (variant === "floating" || page) && !isOpen && showTrigger;
+  const showFloatingButton =
+    (variant === "floating" || page) && !isOpen && showTrigger;
   const containerFixed = isFullScreen || (variant === "floating" && isOpen);
 
   // Exit fullscreen on Escape
@@ -595,7 +623,9 @@ export default function AIChat({
                             : "bg-white dark:bg-gray-800 border rounded-bl-md",
                         )}
                       >
-                        {m.role === "ai" ? renderMessageContent(m.text) : formatMessage(m.text)}
+                        {m.role === "ai"
+                          ? renderMessageContent(m.text)
+                          : formatMessage(m.text)}
                       </div>
                       {m.role === "user" && (
                         <Avatar className="mt-1 h-8 w-8">

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -437,7 +437,7 @@ export default function AIChat({
     }
   };
 
-  const showFloatingButton = (variant === "floating" || page) && !isOpen && showTrigger;
+  const showFloatingButton = variant === "floating" && !isOpen && showTrigger;
   const containerFixed = isFullScreen || (variant === "floating" && isOpen);
 
   // Exit fullscreen on Escape
@@ -549,12 +549,15 @@ export default function AIChat({
                     size="sm"
                     onClick={(e) => {
                       e.stopPropagation();
-                      // Close UI immediately in all modes
+                      // Close immediately
                       setIsFullScreen(false);
-                      setIsOpen(false);
-                      // Fire-and-forget reset; do not block closing
-                      setTimeout(() => clearChat(), 0);
-                      // Do not navigate; hide on same page as requested
+                      if (page) {
+                        setTimeout(() => clearChat(), 0);
+                        navigate("/dashboard");
+                      } else {
+                        setIsOpen(false);
+                        setTimeout(() => clearChat(), 0);
+                      }
                     }}
                     className="h-8 w-8 rounded-full"
                     aria-label="Close chat"

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -437,7 +437,7 @@ export default function AIChat({
     }
   };
 
-  const showFloatingButton = variant === "floating" && !isOpen && showTrigger;
+  const showFloatingButton = (variant === "floating" || page) && !isOpen && showTrigger;
   const containerFixed = isFullScreen || (variant === "floating" && isOpen);
 
   // Exit fullscreen on Escape
@@ -549,15 +549,9 @@ export default function AIChat({
                     size="sm"
                     onClick={(e) => {
                       e.stopPropagation();
-                      // Close immediately
+                      // Hide chat only
                       setIsFullScreen(false);
-                      if (page) {
-                        setTimeout(() => clearChat(), 0);
-                        navigate("/dashboard");
-                      } else {
-                        setIsOpen(false);
-                        setTimeout(() => clearChat(), 0);
-                      }
+                      setIsOpen(false);
                     }}
                     className="h-8 w-8 rounded-full"
                     aria-label="Close chat"

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -513,6 +513,7 @@ export default function AIChat({
               </CardTitle>
               <div className="absolute right-2 top-2 flex gap-1">
                 <Button
+                  type="button"
                   variant="ghost"
                   size="sm"
                   onClick={() => {
@@ -532,6 +533,7 @@ export default function AIChat({
                   )}
                 </Button>
                 <Button
+                  type="button"
                   variant="ghost"
                   size="sm"
                   onClick={clearChat}
@@ -542,18 +544,17 @@ export default function AIChat({
                 </Button>
                 {(variant === "floating" || page) && (
                   <Button
+                    type="button"
                     variant="ghost"
                     size="sm"
-                    onClick={() => {
+                    onClick={(e) => {
+                      e.stopPropagation();
                       // Close UI immediately in all modes
                       setIsFullScreen(false);
                       setIsOpen(false);
                       // Fire-and-forget reset; do not block closing
-                      clearChat();
-                      if (page) {
-                        if (window.history.length > 1) navigate(-1);
-                        else navigate("/dashboard");
-                      }
+                      setTimeout(() => clearChat(), 0);
+                      // Do not navigate; hide on same page as requested
                     }}
                     className="h-8 w-8 rounded-full"
                     aria-label="Close chat"

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -470,11 +470,11 @@ export default function Layout({ children }: LayoutProps) {
         </footer>
       </div>
 
-      {/* Global floating AI Chat (hidden on Chat page) */}
+      {/* Global floating AI Chat (Dashboard only) */}
       <AIChat
         variant="floating"
-        defaultOpen={openChat}
-        showTrigger={location.pathname !== "/chat"}
+        defaultOpen={openChat && location.pathname === "/dashboard"}
+        showTrigger={location.pathname === "/dashboard"}
       />
 
       {/* Mobile sidebar overlay */}

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -9,6 +9,7 @@ export type ChatMessage = {
 
 type ChatState = {
   messages: ChatMessage[];
+  hydrated: boolean;
   setMessages: (
     updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[]),
   ) => void;
@@ -20,6 +21,7 @@ export const useChatStore = create<ChatState>()(
   persist(
     (set, get) => ({
       messages: [],
+      hydrated: false,
       setMessages: (updater) =>
         set((state) => ({
           messages:
@@ -34,7 +36,13 @@ export const useChatStore = create<ChatState>()(
     }),
     {
       name: "chat-storage",
-      partialize: (state) => ({ messages: state.messages }),
+      partialize: (state) => ({ messages: state.messages, hydrated: state.hydrated }),
+      onRehydrateStorage: () => {
+        return () => {
+          // mark as hydrated after rehydration completes
+          useChatStore.setState({ hydrated: true });
+        };
+      },
     },
   ),
 );

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -36,7 +36,7 @@ export const useChatStore = create<ChatState>()(
     }),
     {
       name: "chat-storage",
-      partialize: (state) => ({ messages: state.messages, hydrated: state.hydrated }),
+      partialize: (state) => ({ messages: state.messages }),
       onRehydrateStorage: () => {
         return () => {
           // mark as hydrated after rehydration completes


### PR DESCRIPTION
## Purpose

The user wanted to fix the AI chat close button behavior. Initially, clicking the X button was causing the page to become empty instead of just hiding the chat. After fixing that, the user decided it would be better if the X button only hides the chat without clearing/resetting the conversation, preserving the chat history for a better user experience.

## Code changes

- **Fixed chat close behavior**: Modified the X button click handler to only hide the chat (`setIsOpen(false)` and `setIsFullScreen(false)`) instead of navigating away or clearing chat
- **Added table rendering support**: Implemented `renderMessageContent()` function to parse and display JSON tables and markdown tables in AI responses using the Table component
- **Improved chat initialization**: Added hydration check to prevent premature welcome message initialization and removed automatic backend reset
- **Enhanced chat visibility logic**: Updated floating chat to only show on dashboard page and improved scroll lock behavior
- **Code formatting**: Applied consistent formatting to toast notifications and component propsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ae2387e2c09647f390f9bd2d8e842b10/zen-landing)

👀 [Preview Link](https://ae2387e2c09647f390f9bd2d8e842b10-zen-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae2387e2c09647f390f9bd2d8e842b10</projectId>-->
<!--<branchName>zen-landing</branchName>-->